### PR TITLE
Fix BufferGeometry.toNonIndexed groups

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -863,10 +863,10 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		var geometry2 = new BufferGeometry();
+               var geometry2 = new BufferGeometry();
 
-		var indices = this.index.array;
-		var attributes = this.attributes;
+               var indices = this.index.array;
+               var attributes = this.attributes;
 
 		for ( var name in attributes ) {
 
@@ -891,13 +891,19 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			}
 
-			geometry2.addAttribute( name, new BufferAttribute( array2, itemSize ) );
+                       geometry2.addAttribute( name, new BufferAttribute( array2, itemSize ) );
 
-		}
+               }
 
-		return geometry2;
+               var groups = this.groups;
+               for ( var i = 0, l = groups.length; i < l; i ++ ) {
+                       var group = groups[ i ];
+                       geometry2.addGroup( group.start, group.count, group.materialIndex );
+               }
 
-	},
+               return geometry2;
+
+       },
 
 	toJSON: function () {
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -843,12 +843,15 @@ export default QUnit.module( 'Core', () => {
 				0.5, - 0.5, 0.5, 0.5, - 0.5, - 0.5, 0.5, 0.5, - 0.5
 			] );
 
-			geometry.addAttribute( 'position', new BufferAttribute( vertices, 3 ) );
-			geometry.setIndex( index );
+                       geometry.addAttribute( 'position', new BufferAttribute( vertices, 3 ) );
+                       geometry.setIndex( index );
+                       geometry.addGroup( 0, index.count, 0 );
 
-			var nonIndexed = geometry.toNonIndexed();
+                       var nonIndexed = geometry.toNonIndexed();
 
-			assert.deepEqual( nonIndexed.getAttribute( "position" ).array, expected, "Expected vertices" );
+                       assert.deepEqual( nonIndexed.getAttribute( "position" ).array, expected, "Expected vertices" );
+                       assert.strictEqual( nonIndexed.groups.length, 1, "Group is copied" );
+                       assert.deepEqual( nonIndexed.groups[ 0 ], geometry.groups[ 0 ], "Group data matches" );
 
 		} );
 


### PR DESCRIPTION
## Summary
- preserve geometry groups when converting to non-indexed
- test BufferGeometry.toNonIndexed retains group data

## Testing
- `npm test` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844554246c08327b54848dcb2270b0d